### PR TITLE
Update `net/html` package at main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"encoding/xml"
 	"flag"
 	"fmt"
-	"github.com/golang/net/html"
+	"golang.org/x/net/html"
 	"io"
 	"log"
 	"net/http"


### PR DESCRIPTION
When you try to `go get` it, it returned:

``` sh
go/src/github.com/patrickmn/osg/main.go:8:2: code in directory go/src/github.com/golang/net/html expects import "golang.org/x/net/html"
```

With this patch it's "all safe". 😉 
