### PR TITLE
fix timezones by using the reference timezone expected by Go

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ const (
 )
 
 var (
-	// Sitemap time format is 2012-05-06T02:23:17+00:00
+	// Sitemap time format is 2006-01-02T15:04:05-07:00
 	SitemapTimeFormat         = strings.Replace(time.RFC3339, "Z", "-", -1)
 	MaxDepth                  = 500
 	throttle          *uint   = flag.Uint("c", 1, "pages to crawl at once")

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ const (
 
 var (
 	// Sitemap time format is 2012-05-06T02:23:17+00:00
-	SitemapTimeFormat         = strings.Replace(time.RFC3339, "Z", "+", -1)
+	SitemapTimeFormat         = strings.Replace(time.RFC3339, "Z", "-", -1)
 	MaxDepth                  = 500
 	throttle          *uint   = flag.Uint("c", 1, "pages to crawl at once")
 	maxCrawl          *uint   = flag.Uint("max-crawl", 0, "maximum number of pages to crawl (0 = unlimited)")


### PR DESCRIPTION
Go's reference date uses -07:00 for the timezone, so we need to use that in the time format. If we don't, the timezone in the date provided by the server will be ignored and an incorrect timezone of +07:00 will be added instead. Timezones that are + will still be generated correctly.